### PR TITLE
little plus for new users

### DIFF
--- a/configs/config.json.example
+++ b/configs/config.json.example
@@ -1,5 +1,5 @@
 {
-    "auth_service": "google",
+    "auth_service": "google or ptc",
     "username": "YOUR_USERNAME",
     "password": "YOUR_PASSWORD",
     "location": "SOME_LOCATION",


### PR DESCRIPTION
## Short Description:

Simple add in config file `"auth_service": "google or ptc"`
## Fixes/Resolves/Closes (please use correct syntax):
## 
## 
## 

Only ad a double solution for people have google account or Pokémon trainer club account.
